### PR TITLE
Increase portability of the installer.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2012-05-25  Raphael 'kena' Poss  <r.c.poss@uva.nl>
+
+	Increase portability of the installer.
+
+	* installer/rules/hlsimcore.mk,
+	* installer/rules/gcc.mk,
+	* installer/rules/binutils.mk: Use `$(MAKE)' instead of `make'.
+
 2012-04-30  Raphael 'kena' Poss  <r.c.poss@uva.nl>
 
 	Update licensing and copyright information.

--- a/installer/rules/binutils.mk
+++ b/installer/rules/binutils.mk
@@ -49,7 +49,7 @@ $(BINUTILS_BUILD)-%/configure_done: $(BINUTILS_SRC)/configure $(REQTAG)
 	                  LDFLAGS="$(CFLAGS) $(LDFLAGS)" \
 			   --disable-werror \
 	                   --prefix=$(REQDIR)
-	cd $(BINUTILS_BUILD)-$* && make clean
+	cd $(BINUTILS_BUILD)-$* && $(MAKE) clean
 	touch $@
 
 $(BINUTILS_BUILD)-%/build_done: $(BINUTILS_BUILD)-%/configure_done

--- a/installer/rules/gcc.mk
+++ b/installer/rules/gcc.mk
@@ -56,7 +56,7 @@ $(GCC_BUILD)-%/configure_done: $(GCC_SRC)/configure $(REQDIR)/.binutils-installe
 	                       $(GCC_CONFIG_FLAGS) && \
 	  $(GREP) -v 'maybe-[a-z]*-target-\(libgcc\|libiberty\|libgomp\|zlib\)' <Makefile >Makefile.tmp && \
 	  mv -f Makefile.tmp Makefile
-	cd $(GCC_BUILD)-$* && make clean
+	cd $(GCC_BUILD)-$* && $(MAKE) clean
 	touch $@
 
 $(GCC_BUILD)-%/build_done: $(GCC_BUILD)-%/configure_done

--- a/installer/rules/hlsimcore.mk
+++ b/installer/rules/hlsimcore.mk
@@ -48,7 +48,7 @@ $(HLSIM_BUILD)-%/configure_done: $(HLSIM_SRC)/configure $(PTL_INST_TARGETS)
 			  CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" \
 	                  LDFLAGS="$(LDFLAGS)" \
 	                   --with-ptl-includedir="$(SLDIR)/include/$*" --with-ptl-libdir="$(SLDIR)/lib/$*"
-	cd $(HLSIM_BUILD)-$* && make clean
+	cd $(HLSIM_BUILD)-$* && $(MAKE) clean
 	touch $@
 
 $(HLSIM_BUILD)-%/build_done: $(HLSIM_BUILD)-%/configure_done


### PR DESCRIPTION
- installer/rules/hlsimcore.mk,
- installer/rules/gcc.mk,
- installer/rules/binutils.mk: Use `$(MAKE)' instead of`make'.
